### PR TITLE
Prevent error when session has expired

### DIFF
--- a/src/Controllers/Language.php
+++ b/src/Controllers/Language.php
@@ -72,7 +72,10 @@ class Language extends Controller
 
             $session->setPreviousUrl($url);
         }
-
-        return redirect($session->previousUrl());
+        return redirect(
+            $session->previousUrl()
+            ? $session->previousUrl()
+            : ( config('language.url') ? url('/' . $locale) : url('/') )
+        );
     }
 }

--- a/src/Controllers/Language.php
+++ b/src/Controllers/Language.php
@@ -75,7 +75,7 @@ class Language extends Controller
         return redirect(
             $session->previousUrl()
             ? $session->previousUrl()
-            : ( config('language.url') ? url('/' . $locale) : url('/') )
+            : (config('language.url') ? url('/' . $locale) : url('/'))
         );
     }
 }


### PR DESCRIPTION
When using the 'back' route and the session expired between last page visit and language switch, it produces the error 'Object of class Illuminate\Routing\Redirector could not be converted to string'. This patch uses $session->previousUrl() only if set, if not it goes back to home.