### PR TITLE
fix regression introduced in d82266a8c496fc51fd4b86881e860d46faa51f17

### DIFF
--- a/src/Middleware/SetLocale.php
+++ b/src/Middleware/SetLocale.php
@@ -48,7 +48,8 @@ class SetLocale
         if (config('language.auto')) {
             $agent = new Agent();
 
-            $this->setLocale(reset($agent->languages()));
+            $language = reset($agent->languages());
+            $this->setLocale($language);
         } else {
             $this->setLocale(config('app.locale'));
         }


### PR DESCRIPTION
`Only variables should be passed by reference` due to using the return if `reset()` as a method parameter